### PR TITLE
Support Panko::Response inside serializer attributes

### DIFF
--- a/lib/panko/response.rb
+++ b/lib/panko/response.rb
@@ -43,11 +43,29 @@ module Panko
       writer.to_s
     end
 
+    def as_json(_options = nil)
+      build(@data)
+    end
+
     def self.create
       Response.new(yield ResponseCreator)
     end
 
     private
+
+    def build(data)
+      return data.map { |v| build(v) } if data.is_a?(Array)
+      return data.each_with_object({}) { |(k, v), h| h[k.to_s] = build(v) } if data.is_a?(Hash)
+
+      if data.is_a?(Panko::ArraySerializer) ||
+          data.is_a?(Panko::Serializer) ||
+          data.is_a?(Panko::Response) ||
+          data.is_a?(Panko::JsonValue)
+        Oj.load(data.to_json)
+      else
+        data.as_json
+      end
+    end
 
     def write(writer, data, key = nil)
       return write_array(writer, data, key) if data.is_a?(Array)

--- a/spec/panko/serializer_spec.rb
+++ b/spec/panko/serializer_spec.rb
@@ -743,4 +743,43 @@ describe Panko::Serializer do
       end
     end
   end
+
+  context "response integration" do
+    class ResponseFooSerializer < Panko::Serializer
+      attributes :name, :address
+    end
+
+    class HolderWithResponseSerializer < Panko::Serializer
+      attributes :wrapped_object
+
+      def wrapped_object
+        Panko::Response.create do |r|
+          {
+            custom: {
+              name: object.name,
+              data: r.array_serializer(object.foos, ResponseFooSerializer)
+            }
+          }
+        end
+      end
+    end
+
+    it "serializes response returned from attribute" do
+      foo1 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      foo2 = Foo.create(name: Faker::Lorem.word, address: Faker::Lorem.word).reload
+      holder = FoosHolder.create(name: Faker::Lorem.word, foos: [foo1, foo2]).reload
+
+      expect(holder).to serialized_as(HolderWithResponseSerializer, {
+        "wrapped_object" => {
+          "custom" => {
+            "name" => holder.name,
+            "data" => [
+              {"name" => foo1.name, "address" => foo1.address},
+              {"name" => foo2.name, "address" => foo2.address}
+            ]
+          }
+        }
+      })
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- add `as_json` support for `Panko::Response` so it can be nested
- test serializer attribute returning a `Panko::Response`

## Testing
- `BUNDLE_GEMFILE=gemfiles/7.1.0.gemfile bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_b_684acebbbee48321a691e4fff33a4e6b